### PR TITLE
Rework top level ./configure script

### DIFF
--- a/configure
+++ b/configure
@@ -4,4 +4,6 @@
 # all of its config scripts in a different directory than the configure
 # script itself.
 
-( CFLAGS="-g" ; export CFLAGS ; cd scripts ; ./configure "$@" )
+export CFLAGS="-g"
+cd scripts
+exec ./configure "$@"

--- a/configure
+++ b/configure
@@ -4,6 +4,6 @@
 # all of its config scripts in a different directory than the configure
 # script itself.
 
-export CFLAGS="-g"
+export CFLAGS="$CFLAGS -g"
 cd scripts
 exec ./configure "$@"


### PR DESCRIPTION
This change makes both `CFLAGS` and the return code work when using the top level `./configure` script.