### PR TITLE
Increase OBJHASHSIZE

### DIFF
--- a/base/objlist.h
+++ b/base/objlist.h
@@ -192,9 +192,8 @@ struct Permutation {
     struct Permutation *next;
 };
 
-#define OBJHASHSIZE 997 /* the size of the object and instance hash lists */
+#define OBJHASHSIZE 42073 /* the size of the object and instance hash lists */
                         /* prime numbers are good choices as hash sizes */
-                        /* 101 is a good number for IBMPC */
 
 /* cell definition for hash table */
 /* NOTE: "file" must come first for the hash matching by name and file */


### PR DESCRIPTION
I have a design that is taking quite a long time for netgen to complete LVS
checking. Profiles show a large chunk of runtime is in the hash functions.

Some of the hashtables are very sparsely populated, but others are
heavily used. One hashtable has chains of over 250. Longer term it would
be worth investigating resizing the hashtables (or perhaps using other
data strutures), but for now I looked at what changing the number of
hash buckets (OBJHASHSIZE) does for performance:

OBJHASHSIZE	time (mm:ss)
997		24:18
10093		 4:42
42073		 3:12
104729		 2:51

I somewhat arbitrarily chose 42073 which gives us a 7.6x improvement in
runtime.