### PR TITLE
Fix missing prototype for ReadVerilogFile function

### DIFF
--- a/base/netgen.h
+++ b/base/netgen.h
@@ -65,6 +65,15 @@ extern void AssignCircuits(char *name1, int file1, char *name2, int file2);
 /* flatten.c */
 extern int PrematchLists(char *, int, char *, int);
 
+/* verilog.c */
+struct cellstack {
+	char *cellname;
+	struct cellstack *next;
+};
+
+void ReadVerilogFile(char *fname, int filenum, struct cellstack **CellStackPtr,
+	int blackbox);
+
 /* Define (enumerate) various device classes, largely based on SPICE	*/
 /* model types, mixed with some ext/sim types.				*/
 

--- a/base/spice.c
+++ b/base/spice.c
@@ -474,15 +474,6 @@ void CleanupSubcell() {
 }
 
 /*------------------------------------------------------*/
-/* Structure for stacking nested subcircuit definitions */
-/*------------------------------------------------------*/
-
-struct cellstack {
-   char *cellname;
-   struct cellstack *next;
-};
-
-/*------------------------------------------------------*/
 /* Push a subcircuit name onto the stack		*/
 /*------------------------------------------------------*/
 

--- a/base/verilog.c
+++ b/base/verilog.c
@@ -632,11 +632,6 @@ void CleanupModule() {
 /* Structure for stacking nested module definitions	*/
 /*------------------------------------------------------*/
 
-struct cellstack {
-   char *cellname;
-   struct cellstack *next;
-};
-
 /* Forward declarations */
 extern void IncludeVerilog(char *, int, struct cellstack **, int);
 


### PR DESCRIPTION
Dear Tim,

I would like to propose this minor change to the code; it unbreaks OpenBSD port for mips64 arch, but it could be of general interest, since it fixes a missing function prototype.

The involved function is `ReadVerilogFile` in `verilog.c`; I added the prototype in `base/netgen.h`, moving there the `cellstack` struc definition too (from `base/spice.c`).

Let me know if this is acceptable.

All the best

--
Alessandro