### PR TITLE
If the setup file is present and will be read,

### DIFF
--- a/tcltk/netgen.tcl.in
+++ b/tcltk/netgen.tcl.in
@@ -485,6 +485,9 @@ proc netgen::lvs { name1 name2 {setupfile setup.tcl} {logfile comp.out} args} {
       if {![catch {open $setupfile r} fsetup]} {
 	 set sline 0
 	 set command {}
+	 # preface reading of setup file with defaults
+	 netgen::permute default
+	 netgen::property default
 	 while {[gets $fsetup line] >= 0} {
 	    incr sline
 	    append command $line "\n"


### PR DESCRIPTION

Another option to address issue #22  - this one automatically prepends the permute default and property default commands on the fly -- no need for these to lead a custom setup file