### PR TITLE
Added command line options -help and -version

### DIFF
--- a/tcltk/Makefile
+++ b/tcltk/Makefile
@@ -4,6 +4,7 @@ SRCS = tclnetgen.c
 
 include ${NETGENDIR}/defs.mak
 
+VERSION := $(shell cat ../VERSION)
 EXTRA_LIBS = ${MAIN_EXTRA_LIBS}
 
 DFLAGS += -DNETGEN_DATE="\"`date`\""
@@ -32,11 +33,12 @@ netgen.tcl: netgen.tcl.in
 	    -e 's%SHDLIB_EXT%${SHDLIB_EXT}%g' \
 	    netgen.tcl.in > netgen.tcl
 
-netgen.sh: netgen.sh.in
+netgen.sh: netgen.sh.in ../VERSION
 	sed -e 's%TCL_DIR%${TCLDIR}%g' \
 	    -e 's%PY_DIR%${PYDIR}%g' \
 	    -e 's%TCLLIB_DIR%${TCL_LIB_DIR}%g' \
 	    -e 's%WISH_EXE%${WISH_EXE}%g' \
+	    -e 's%=VERSION%=${VERSION}%' \
 	    netgen.sh.in > netgen.sh
 
 $(DESTDIR)${INSTALL_TCLDIR}/%: %

--- a/tcltk/netgen.sh.in
+++ b/tcltk/netgen.sh.in
@@ -16,6 +16,7 @@ TKCON=true
 BATCH=
 GUI=
 NETGEN_WISH=WISH_EXE
+VERSION=VERSION
 export NETGEN_WISH
 
 # Hacks for Cygwin
@@ -24,6 +25,20 @@ if [ ${TERM:=""} = "cygwin" ]; then
    export DISPLAY=${DISPLAY:=":0"}
 fi
 
+usage() {
+   echo "Usage: netgen [-noconsole] [<command_line>]"
+   echo "       netgen -batch <command_line>"
+   echo "       netgen -gui"
+   echo "       netgen [-help | -version]"
+   echo "Options:"
+   echo "  -noconsole   no console window, interpreter prompt will be in the terminal"
+   echo "  -batch       implies -noconsole, and exits after executing <command_line> argument"
+   echo "  -gui         runs the LVS manager"
+   echo "  -help        show help and exit"
+   echo "  -version     show version and exit"
+   exit 1
+}
+
 # Preserve quotes in arguments (thanks, Stackoverflow!)
 arglist=''
 for i in "$@" ; do
@@ -31,6 +46,8 @@ for i in "$@" ; do
       -noc*) TKCON=;;
       -bat*) BATCH=true; TKCON=;;
       -gui) GUI=true; TKCON=;;
+      -v | -version | --version) echo ${VERSION}; exit 1;;
+      -h | -help | --help) usage;;
       *) arglist="$arglist${arglist:+ }\"${i//\"/\\\"}\"";;
    esac
 done 


### PR DESCRIPTION
Taking care of some long hanging fruit, addresses issue #8 

Didn't see -gui documented on the OCD netgen webpage, looks like the feature may be experimental, or not ready for primetime, included it in the help anyway