### PR TITLE
Add missing newlines to log file messages.

### DIFF
--- a/base/netcmp.c
+++ b/base/netcmp.c
@@ -6892,13 +6892,6 @@ int reorderpins(struct hashlist *p, int file)
 		"Ordering will be arbitrary.\n", tc2->name);
 
     for (ob = ptr->cell; ob != NULL; ) {
-        /* Catch badness */
-	if (ob->next && (ob->next->node > 99999)) {
-	    if (ob->next->node % 10000 == 0) {  /* print once every 10000 nodes over 100000 */
-		Fprintf(stdout, "Bad node. Node count %d\n", ob->next->node);
-	    }
-	} 
-
 	if (ob->type == FIRSTPIN) {
 	    if ((*matchfunc)(ob->model.class, tc2->name)) {
 		char *sptr = ob->instance.name;

--- a/base/netcmp.c
+++ b/base/netcmp.c
@@ -6894,7 +6894,7 @@ int reorderpins(struct hashlist *p, int file)
     for (ob = ptr->cell; ob != NULL; ) {
         /* Catch badness */
 	if (ob->next && (ob->next->node > 99999)) {
-	    if (ob->next->node % 100 == 0) {  /* print once every 100 nodes over 100000 */
+	    if (ob->next->node % 10000 == 0) {  /* print once every 10000 nodes over 100000 */
 		Fprintf(stdout, "Bad node. Node count %d\n", ob->next->node);
 	    }
 	} 

--- a/base/netcmp.c
+++ b/base/netcmp.c
@@ -6894,7 +6894,9 @@ int reorderpins(struct hashlist *p, int file)
     for (ob = ptr->cell; ob != NULL; ) {
         /* Catch badness */
 	if (ob->next && (ob->next->node > 100000)) {
-	    Fprintf(stdout, "Bad.\n");
+	    if (ob->next->node % 100000 == 0) {    
+		Fprintf(stdout, "Bad node. Node count %d\n", ob->next->node);
+	    }
 	} 
 
 	if (ob->type == FIRSTPIN) {

--- a/base/netcmp.c
+++ b/base/netcmp.c
@@ -6893,8 +6893,8 @@ int reorderpins(struct hashlist *p, int file)
 
     for (ob = ptr->cell; ob != NULL; ) {
         /* Catch badness */
-	if (ob->next && (ob->next->node > 100000)) {
-	    if (ob->next->node % 100000 == 0) {    
+	if (ob->next && (ob->next->node > 99999)) {
+	    if (ob->next->node % 100 == 0) {  /* print once every 100 nodes over 100000 */
 		Fprintf(stdout, "Bad node. Node count %d\n", ob->next->node);
 	    }
 	} 

--- a/tcltk/netgen.tcl.in
+++ b/tcltk/netgen.tcl.in
@@ -566,7 +566,7 @@ proc netgen::lvs { name1 name2 {setupfile setup.tcl} {logfile comp.out} args} {
 	           netgen::flatten class "[lindex $endval 0] $fnum1"
 	           netgen::flatten class "[lindex $endval 1] $fnum2"
 	       } else {
-	           netgen::log put "  Continuing with black-boxed subcircuits $endval"
+	           netgen::log put "  Continuing with black-boxed subcircuits $endval\n"
 		   lappend matcherr [lindex $endval 0]
 	           # Match pins
                    netgen::log echo off
@@ -611,13 +611,13 @@ proc netgen::lvs { name1 name2 {setupfile setup.tcl} {logfile comp.out} args} {
          if {[netgen::print queue] != {}} {
 	    if {([lsearch $noflat [lindex $endval 1]] == -1) &&
 		    ([lsearch $noflat [lindex $endval 1]] == -1)} {
-	       netgen::log put "  Flattening non-matched subcircuits $endval"
+	       netgen::log put "  Flattening non-matched subcircuits $endval\n"
 	       netgen::flatten class "[lindex $endval 0] $fnum1"
 	       netgen::flatten class "[lindex $endval 1] $fnum2"
 	    } else {
-	       netgen::log put "  Continuing with black-boxed subcircuits $endval"
+	       netgen::log put "  Continuing with black-boxed subcircuits $endval\n"
 	       lappend matcherr [lindex $endval 0]
-	       netgen::log put "  Continuing with black-boxed subcircuits $endval"
+	       netgen::log put "  Continuing with black-boxed subcircuits $endval\n"
 	       lappend matcherr [lindex $endval 0]
 	       # Match pins
                netgen::log echo off

--- a/tcltk/netgen.tcl.in
+++ b/tcltk/netgen.tcl.in
@@ -562,7 +562,7 @@ proc netgen::lvs { name1 name2 {setupfile setup.tcl} {logfile comp.out} args} {
             if {[netgen::print queue] != {}} {
 	       if {([lsearch $noflat [lindex $endval 0]] == -1) &&
 			([lsearch $noflat [lindex $endval 1]] == -1)} {
-	           netgen::log put "  Flattening non-matched subcircuits $endval"
+	           netgen::log put "  Flattening non-matched subcircuits $endval\n"
 	           netgen::flatten class "[lindex $endval 0] $fnum1"
 	           netgen::flatten class "[lindex $endval 1] $fnum2"
 	       } else {


### PR DESCRIPTION
Missing newlines caused some messages to be written to the same line in the log file. This fixes that. Also removes a debugging statement.

```
1018c1025,1026
<   Flattening non-matched subcircuits wordline_driver wordline_driverWarning: Equate pins:  cell sky130_fd_pr__special_nfet_latch has no definition, treated as a black box.
---
>   Flattening non-matched subcircuits wordline_driver wordline_driver
> Warning: Equate pins:  cell sky130_fd_pr__special_nfet_latch has no definition, treated as a black box.
9628c9652,9653
<   Flattening non-matched subcircuits wordline_driver_array wordline_driver_arrayClass bitcell_array:  Merged 16384 devices.
---
>   Flattening non-matched subcircuits wordline_driver_array wordline_driver_array
> Class bitcell_array:  Merged 16384 devices.
```