### PR TITLE
Remove disconnected ports after flattening. Recursively flatten unmatched cells with no matching devices. (updated)

### DIFF
--- a/base/flatten.c
+++ b/base/flatten.c
@@ -1615,7 +1615,8 @@ PrematchLists(char *name1, int file1, char *name2, int file2)
 			}
 		    }
 		    else {
-		       match = 0;
+		       // cell exists in one circuit but not the other, so flatten it.
+		       // match = 0;
 		       break;
 		    }
 		}


### PR DESCRIPTION
This is a partial fix to issue #29 item 3. 
Instead of removing disconnected ports when matching pins, this change removes all disconnected ports in a circuit after flattening. 

Test data: Extract the tarball into a new directory and run `netgen -batch source setup_file.gds.lvs`.

[precharge.lvs.tar.gz](https://github.com/RTimothyEdwards/netgen/files/7336735/precharge.lvs.tar.gz)

Before the change, `precharge_0.lvs.gds.log` will show a clean LVS result with 1 disconnected port. 

After the change, `precharge_0.lvs.gds.log` will show a clean LVS result with no disconnected ports.

Before the change, `precharge_array.lvs.gds.log` will show a bad LVS result with 1 disconnected port and many unmatched nets. 

After the change, `precharge_array.lvs.gds.log` will show a clean LVS result with 1 disconnected port.

May also have an effect on this openram slack discussion https://skywater-pdk.slack.com/archives/C017UA7LEUV/p1633464674036700

