### PR TITLE
Mismatched instance flattening change.

### DIFF
--- a/base/flatten.c
+++ b/base/flatten.c
@@ -1582,7 +1582,8 @@ PrematchLists(char *name1, int file1, char *name2, int file2)
 			}
 		    }
 		    else {
-		       match = 0;
+		       // cell exists in one circuit but not the other, so flatten it.
+		       // match = 0;
 		       break;
 		    }
 		}

--- a/tcltk/tclnetgen.c
+++ b/tcltk/tclnetgen.c
@@ -2194,6 +2194,7 @@ _netcmp_compare(ClientData clientData,
    CreateTwoLists(name1, fnum1, name2, fnum2, dolist);
    while (PrematchLists(name1, fnum1, name2, fnum2) > 0) {
       Fprintf(stdout, "Making another compare attempt.\n");
+      Printf("Flattened mismatched instances and attempting compare again.\n");
       CreateTwoLists(name1, fnum1, name2, fnum2, dolist);
    }
 


### PR DESCRIPTION
When comparing instance counts to determine is flattening makes a better match, flatten cells that have no instances in common.
Display a screen message to indicate a re-compare after flattening.

Changes to screen output:

```
| Contents of circuit 1:  Circuit: 'pinv_2'                                            || Contents of circuit 1:  Circuit: 'pinv_2'                                            
| Circuit pinv_2 contains 2 device instances.                                          || Circuit pinv_2 contains 2 device instances.                                          
|   Class: nmos_m3_w1_680_sli_dli_da_p instances:   1                                  ||   Class: nmos_m3_w1_680_sli_dli_da_p instances:   1                                  
|   Class: pmos_m3_w1_650_sli_dli_da_p instances:   1                                  ||   Class: pmos_m3_w1_650_sli_dli_da_p instances:   1                                  
| Circuit contains 4 nets.                                                             || Circuit contains 4 nets.                                                             
| Contents of circuit 2:  Circuit: 'pinv_2'                                            || Contents of circuit 2:  Circuit: 'pinv_2'                                            
| Circuit pinv_2 contains 2 device instances.                                          || Circuit pinv_2 contains 2 device instances.                                          
|   Class: sky130_fd_pr__nfet_01v8 instances:   1                                      ||   Class: sky130_fd_pr__nfet_01v8 instances:   1                                      
    Class: sky130_fd_pr__pfet_01v8 instances:   1                                      |    Class: sky130_fd_pr__pfet_01v8 instances:   1                                      
  Circuit contains 4 nets.                                                             |  Circuit contains 4 nets.                                                             
                                                                                       |                                                                                       
  Circuit 1 contains 2 devices, Circuit 2 contains 2 devices.                          |  Circuit 1 contains 2 devices, Circuit 2 contains 2 devices.                          
  Circuit 1 contains 4 nets,    Circuit 2 contains 4 nets.                             |  Circuit 1 contains 4 nets,    Circuit 2 contains 4 nets.                             
                                                                                       |                                                                                       
  -------------------------------------------------------------------------------------|  Flattened mismatched instances and attempting compare again.                         
  Contents of circuit 1:  Circuit: 'pinv_2'                                            |  Contents of circuit 1:  Circuit: 'pinv_2'                                            
  Circuit pinv_2 contains 2 device instances.                                          |  Circuit pinv_2 contains 2 device instances.                                          
    Class: sky130_fd_pr__nfet_01v8 instances:   1                                      |    Class: sky130_fd_pr__nfet_01v8 instances:   1                                      
    Class: sky130_fd_pr__pfet_01v8 instances:   1                                      |    Class: sky130_fd_pr__pfet_01v8 instances:   1                                      
  Circuit contains 4 nets.                                                             |  Circuit contains 4 nets.                                                             
  Contents of circuit 2:  Circuit: 'pinv_2'                                            |  Contents of circuit 2:  Circuit: 'pinv_2'                                            
- Circuit pinv_2 contains 2 device instances.                                          |- Circuit pinv_2 contains 2 device instances.                                          
|   Class: sky130_fd_pr__nfet_01v8 instances:   1                                      ||   Class: sky130_fd_pr__nfet_01v8 instances:   1                                      
|   Class: sky130_fd_pr__pfet_01v8 instances:   1                                      ||   Class: sky130_fd_pr__pfet_01v8 instances:   1                                      
| Circuit contains 4 nets.                                                             || Circuit contains 4 nets.                                                             
|                                                                                      ||                                                                                      
| Circuit 1 contains 2 devices, Circuit 2 contains 2 devices.                          || Circuit 1 contains 2 devices, Circuit 2 contains 2 devices.                          
| Circuit 1 contains 4 nets,    Circuit 2 contains 4 nets.                             || Circuit 1 contains 4 nets,    Circuit 2 contains 4 nets.                             
|                                                                                      ||                                                                                      
| Netlists match uniquely.                                                             || Netlists match uniquely.                                                             
```

Changes to processing
```
| Circuit control_logic_r contains 174 device instances.                               || Circuit control_logic_r contains 174 device instances.                               
|   Class: sky130_fd_pr__nfet_01v8 instances:  87                                      ||   Class: sky130_fd_pr__nfet_01v8 instances:  87                                      
|   Class: sky130_fd_pr__pfet_01v8 instances:  87                                      ||   Class: sky130_fd_pr__pfet_01v8 instances:  87                                      
| Circuit contains 102 nets.                                                           || Circuit contains 102 nets.                                                           
| Contents of circuit 2:  Circuit: 'control_logic_r'                                   || Contents of circuit 2:  Circuit: 'control_logic_r'                                   
| Circuit control_logic_r contains 64 device instances.                                || Circuit control_logic_r contains 64 device instances.                                
|   Class: sky130_fd_pr__nfet_01v8 instances:   5                                      ||   Class: sky130_fd_pr__nfet_01v8 instances:   5                                      
|   Class: pand2_0               instances:   2                                        ||   Class: pand2_0               instances:   2                                        
|   Class: pinv_0                instances:   1                                        ||   Class: pinv_0                instances:   1                                        
|   Class: pinv_6                instances:   1                                        ||   Class: pinv_6                instances:   1                                        
|   Class: pnand2_1              instances:   1                                        ||   Class: pnand2_1              instances:   1                                        
|   Class: pdriver_2             instances:   1                                        ||   Class: pdriver_2             instances:   1                                        
|   Class: pdriver_5             instances:   1                                        ||   Class: pdriver_5             instances:   1                                        
|   Class: dff_buf_0             instances:   1                                        ||   Class: dff_buf_0             instances:   1                                        
|   Class: sky130_fd_pr__pfet_01v8 instances:   5                                      ||   Class: sky130_fd_pr__pfet_01v8 instances:   5                                      
|   Class: pinv_20               instances:  45                                        ||   Class: pinv_20               instances:  45                                        
    Class: pand3_0               instances:   1                                        |    Class: pand3_0               instances:   1                                        
  Circuit contains 65 nets.                                                            |  Circuit contains 65 nets.                                                            
                                                                                       |                                                                                       
  Circuit 1 contains 174 devices, Circuit 2 contains 64 devices. *** MISMATCH ***      |  Circuit 1 contains 174 devices, Circuit 2 contains 64 devices. *** MISMATCH ***      
  Circuit 1 contains 102 nets,    Circuit 2 contains 65 nets. *** MISMATCH ***         |  Circuit 1 contains 102 nets,    Circuit 2 contains 65 nets. *** MISMATCH ***         
                                                                                       |                                                                                       
  -------------------------------------------------------------------------------------|  Flattened mismatched instances and attempting compare again.                         
  Contents of circuit 1:  Circuit: 'control_logic_r'                                   |  Contents of circuit 1:  Circuit: 'control_logic_r'                                   
  Circuit control_logic_r contains 174 device instances.                               |  Circuit control_logic_r contains 174 device instances.                               
    Class: sky130_fd_pr__nfet_01v8 instances:  87                                      |    Class: sky130_fd_pr__nfet_01v8 instances:  87                                      
    Class: sky130_fd_pr__pfet_01v8 instances:  87                                      |    Class: sky130_fd_pr__pfet_01v8 instances:  87                                      
  Circuit contains 102 nets.                                                           |  Circuit contains 102 nets.                                                           
  Contents of circuit 2:  Circuit: 'control_logic_r'                                   |  Contents of circuit 2:  Circuit: 'control_logic_r'                                   
  Circuit control_logic_r contains 114 device instances.                               |  Circuit control_logic_r contains 151 device instances.                               
    Class: sky130_fd_pr__nfet_01v8 instances:  54                                      |    Class: sky130_fd_pr__nfet_01v8 instances:  72                                      
    Class: pand2_0               instances:   2                                        |    Class: pinv_1                instances:   1                                        
  -------------------------------------------------------------------------------------|    Class: pinv_2                instances:   1                                        
  -------------------------------------------------------------------------------------|    Class: pdriver_0             instances:   2                                        
    Class: pdriver_2             instances:   1                                        |    Class: pdriver_2             instances:   1                                        
  -------------------------------------------------------------------------------------|    Class: pdriver_4             instances:   1                                        
    Class: pdriver_5             instances:   1                                        |    Class: pdriver_5             instances:   1                                        
    Class: dff_buf_0             instances:   1                                        |    Class: sky130_fd_pr__pfet_01v8 instances:  72                                      
    Class: sky130_fd_pr__pfet_01v8 instances:  54                                      |  Circuit contains 87 nets.                                                            
    Class: pand3_0               instances:   1                                        |                                                                                       
  Circuit contains 66 nets.                                                            |  Circuit 1 contains 174 devices, Circuit 2 contains 151 devices. *** MISMATCH ***     
  -------------------------------------------------------------------------------------|  Circuit 1 contains 102 nets,    Circuit 2 contains 86 nets. *** MISMATCH ***         
  -------------------------------------------------------------------------------------|                                                                                       
  -------------------------------------------------------------------------------------|  Flattened mismatched instances and attempting compare again.                         
  -------------------------------------------------------------------------------------|  Contents of circuit 1:  Circuit: 'control_logic_r'                                   
  -------------------------------------------------------------------------------------|  Circuit control_logic_r contains 174 device instances.                               
  -------------------------------------------------------------------------------------|    Class: sky130_fd_pr__nfet_01v8 instances:  87                                      
  -------------------------------------------------------------------------------------|    Class: sky130_fd_pr__pfet_01v8 instances:  87                                      
  -------------------------------------------------------------------------------------|  Circuit 1 contains 102 nets,    Circuit 2 contains 86 nets. *** MISMATCH ***         
  -------------------------------------------------------------------------------------|                                                                                       
  -------------------------------------------------------------------------------------|  Flattened mismatched instances and attempting compare again.                         
  -------------------------------------------------------------------------------------|  Contents of circuit 1:  Circuit: 'control_logic_r'                                   
  -------------------------------------------------------------------------------------|  Circuit control_logic_r contains 174 device instances.                               
  -------------------------------------------------------------------------------------|    Class: sky130_fd_pr__nfet_01v8 instances:  87                                      
  -------------------------------------------------------------------------------------|    Class: sky130_fd_pr__pfet_01v8 instances:  87                                      
  -------------------------------------------------------------------------------------|  Circuit contains 102 nets.                                                           
  -------------------------------------------------------------------------------------|  Contents of circuit 2:  Circuit: 'control_logic_r'                                   
  -------------------------------------------------------------------------------------|  Circuit control_logic_r contains 169 device instances.                               
  -------------------------------------------------------------------------------------|    Class: sky130_fd_pr__nfet_01v8 instances:  82                                      
  -------------------------------------------------------------------------------------|    Class: pinv_17               instances:   1                                        
  -------------------------------------------------------------------------------------|    Class: pinv_3                instances:   2                                        
  -------------------------------------------------------------------------------------|    Class: pinv_6                instances:   2                                        
  -------------------------------------------------------------------------------------|    Class: sky130_fd_pr__pfet_01v8 instances:  82                                      
  -------------------------------------------------------------------------------------|  Circuit contains 95 nets.                                                            
  -------------------------------------------------------------------------------------|                                                                                       
  -------------------------------------------------------------------------------------|  Circuit 1 contains 174 devices, Circuit 2 contains 169 devices. *** MISMATCH ***     
  -------------------------------------------------------------------------------------|  Circuit 1 contains 102 nets,    Circuit 2 contains 94 nets. *** MISMATCH ***         
  -------------------------------------------------------------------------------------|                                                                                       
  -------------------------------------------------------------------------------------|  Flattened mismatched instances and attempting compare again.                         
  -------------------------------------------------------------------------------------|  Contents of circuit 1:  Circuit: 'control_logic_r'                                   
  -------------------------------------------------------------------------------------|  Circuit control_logic_r contains 174 device instances.                               
  -------------------------------------------------------------------------------------|    Class: sky130_fd_pr__nfet_01v8 instances:  87                                      
  -------------------------------------------------------------------------------------|    Class: sky130_fd_pr__pfet_01v8 instances:  87                                      
  -------------------------------------------------------------------------------------|  Circuit contains 102 nets.                                                           
  -------------------------------------------------------------------------------------|  Contents of circuit 2:  Circuit: 'control_logic_r'                                   
  -------------------------------------------------------------------------------------|  Circuit control_logic_r contains 174 device instances.                               
  -------------------------------------------------------------------------------------|    Class: sky130_fd_pr__nfet_01v8 instances:  87                                      
  -------------------------------------------------------------------------------------|    Class: sky130_fd_pr__pfet_01v8 instances:  87                                      
  -------------------------------------------------------------------------------------|  Circuit contains 95 nets.                                                            
                                                                                       |                                                                                       
  Circuit 1 contains 174 devices, Circuit 2 contains 114 devices. *** MISMATCH ***     |  Circuit 1 contains 174 devices, Circuit 2 contains 174 devices.                      
  Circuit 1 contains 102 nets,    Circuit 2 contains 66 nets. *** MISMATCH ***         |  Circuit 1 contains 102 nets,    Circuit 2 contains 94 nets. *** MISMATCH ***         
```
In the example above, `control_logic_r` was completely flattened in the layout but not in the source netlist. netgen would flatten any cells that had the same devices (nfet/pfet) as the layout, but not flatten any other cells (eg. an AND gate consisting of an inverter and a NAND gate). This change corrects that.

This a portion of the change that was backed out in version 1.5.206. 