### PR TITLE
Cosmetic report changes.

### DIFF
--- a/base/netcmp.c
+++ b/base/netcmp.c
@@ -3125,7 +3125,7 @@ int FirstElementPass(struct Element *E, int noflat, int dolist)
   ostr = CALLOC(right_col_end + 2, sizeof(char));
 
   if (Debug == 0) {
-     Fprintf(stdout, "\nSubcircuit summary:\n");
+     Fprintf(stdout, "Subcircuit summary:\n");
      *(ostr + left_col_end) =  '|';
      *(ostr + right_col_end) = '\n';
      *(ostr + right_col_end + 1) = '\0';
@@ -3736,8 +3736,9 @@ void CreateTwoLists(char *name1, int file1, char *name2, int file2, int dolist)
 
     ResetState();
 
+    Fprintf(stdout, "\n");  // blank line before new circuit diagnostics in log file
     /* print preliminary statistics */
-    Printf("Contents of circuit 1:  ");
+    Printf("\nContents of circuit 1:  ");
     DescribeInstance(name1, file1);
     Printf("Contents of circuit 2:  ");
     DescribeInstance(name2, file2);

--- a/base/netgen.c
+++ b/base/netgen.c
@@ -3441,7 +3441,7 @@ int CombineParallel(char *model, int file)
    }
    HashKill(&devdict);
    if (dcnt > 0) {
-      Fprintf(stdout, "Class %s:  Merged %d devices.\n", model, dcnt);
+      Fprintf(stdout, "Class %s(%d):  Merged %d parallel devices.\n", model, file, dcnt);
    }
    FREE(nodecount);
    return dcnt;
@@ -3738,6 +3738,9 @@ int CombineSeries(char *model, int file)
       }
    }
    FREE(instlist);
+   if (scnt > 0) {
+      Fprintf(stdout, "Class %s(%d):  Merged %d series devices.\n", model, file, scnt);
+   }
    return scnt;
 }
 

--- a/base/query.c
+++ b/base/query.c
@@ -807,9 +807,9 @@ void DescribeInstance(char *name, int file)
 
       if (!(tp->flags & CELL_PLACEHOLDER) && (tp->class != CLASS_MODULE))
       {
-	if (disconnectednodes == 0) Fprintf(stderr, "\n");
+	//if (disconnectednodes == 0) Fprintf(stderr, "\n");
         disconnectednodes++;
-        Fprintf(stderr, "Cell %s disconnected node: %s\n", tp->name, ob->name);
+        Fprintf(stderr, "Cell %s(%d) disconnected node: %s\n", tp->name, tp->file, ob->name);
       }
     }
   }

--- a/tcltk/netgen.tcl.in
+++ b/tcltk/netgen.tcl.in
@@ -567,7 +567,8 @@ proc netgen::lvs { name1 name2 {setupfile setup.tcl} {logfile comp.out} args} {
 	           netgen::flatten class "[lindex $endval 1] $fnum2"
 	       } else {
 	           netgen::log put "  Continuing with black-boxed subcircuits $endval\n"
-		   lappend matcherr [lindex $endval 0]
+		   lappend matcherr [lindex $endval 0]"($fnum1)"
+		   lappend matcherr [lindex $endval 1]"($fnum2)"
 	           # Match pins
                    netgen::log echo off
 	           if {$dolist == 1} {
@@ -616,9 +617,8 @@ proc netgen::lvs { name1 name2 {setupfile setup.tcl} {logfile comp.out} args} {
 	       netgen::flatten class "[lindex $endval 1] $fnum2"
 	    } else {
 	       netgen::log put "  Continuing with black-boxed subcircuits $endval\n"
-	       lappend matcherr [lindex $endval 0]"(1)"
-	       netgen::log put "  Continuing with black-boxed subcircuits $endval\n"
-	       lappend matcherr [lindex $endval 0]"(2)"
+	       lappend matcherr [lindex $endval 0]"($fnum1)"
+	       lappend matcherr [lindex $endval 0]"($fnum2)"
 	       # Match pins
                netgen::log echo off
 	       if {$dolist == 1} {
@@ -656,10 +656,10 @@ proc netgen::lvs { name1 name2 {setupfile setup.tcl} {logfile comp.out} args} {
       verify only
    }
    if {$properr != {}} {
-      netgen::log put "The following cells had property errors: $properr\n"
+      netgen::log put "The following cells had property errors:\n " [regsub -all { } $properr "\n "] "\n"
    }
    if {$matcherr != {}} {
-      netgen::log put "The following subcells failed to match: $matcherr\n"
+      netgen::log put "The following subcells failed to match:\n " [regsub -all { } $matcherr "\n "] "\n"
    }
    if {$dolog} {
       netgen::log end


### PR DESCRIPTION
Changed line breaks in log and stdout to better differentiate subcircuits.
Added merged series device counts and differentiated from parallel merged device counts.
Added file number to disconnected net, merged count messages.
Changed black box errors to show file numbers instead of hard coded values.
Final error cell list changed from all on one line to one per line.
Removed redundant display in black box warning.

I didn't have test data for the changes relating to black boxes, but here's the results of the other changes.

stdout changes:
1. Separate `no devices` message from next subcircuit.
Before
```
Logging to file "/home/*/mpw-2/caravel-lvs/openlane/chip_io/runs/cvc/results/lvs/chip_io.lvs.gds.log" enabled
Contents of circuit 1:  Circuit: 'sky130_fd_pr__nfet_g5v0d10v5'
Circuit sky130_fd_pr__nfet_g5v0d10v5 contains 0 device instances.
Circuit contains 0 nets.
Contents of circuit 2:  Circuit: 'sky130_fd_pr__nfet_g5v0d10v5'
Circuit sky130_fd_pr__nfet_g5v0d10v5 contains 0 device instances.
Circuit contains 0 nets.

Circuit sky130_fd_pr__nfet_g5v0d10v5 contains no devices.
Contents of circuit 1:  Circuit: 'sky130_fd_pr__pfet_g5v0d10v5'
Circuit sky130_fd_pr__pfet_g5v0d10v5 contains 0 device instances.
Circuit contains 0 nets.
Contents of circuit 2:  Circuit: 'sky130_fd_pr__pfet_g5v0d10v5'
Circuit sky130_fd_pr__pfet_g5v0d10v5 contains 0 device instances.
Circuit contains 0 nets.
```
After:
```
Logging to file "/home/*/mpw-2/caravel-lvs/openlane/chip_io/runs/cvc/results/lvs/chip_io.lvs.gds.log" enabled

Contents of circuit 1:  Circuit: 'sky130_fd_pr__nfet_g5v0d10v5'
Circuit sky130_fd_pr__nfet_g5v0d10v5 contains 0 device instances.
Circuit contains 0 nets.
Contents of circuit 2:  Circuit: 'sky130_fd_pr__nfet_g5v0d10v5'
Circuit sky130_fd_pr__nfet_g5v0d10v5 contains 0 device instances.
Circuit contains 0 nets.

Circuit sky130_fd_pr__nfet_g5v0d10v5 contains no devices.

Contents of circuit 1:  Circuit: 'sky130_fd_pr__pfet_g5v0d10v5'
Circuit sky130_fd_pr__pfet_g5v0d10v5 contains 0 device instances.
Circuit contains 0 nets.
Contents of circuit 2:  Circuit: 'sky130_fd_pr__pfet_g5v0d10v5'
Circuit sky130_fd_pr__pfet_g5v0d10v5 contains 0 device instances.
Circuit contains 0 nets.
```
2. Separate `Circuits match correctly` and `Netlists match uniquely` from next subcircuit.
Before:
```
Contents of circuit 1:  Circuit: 'sky130_fd_io__gpiov2_octl_mux'
Circuit sky130_fd_io__gpiov2_octl_mux contains 4 device instances.
  Class: sky130_fd_pr__nfet_g5v0d10v5 instances:   2
  Class: sky130_fd_pr__pfet_g5v0d10v5 instances:   2
Circuit contains 7 nets.
Contents of circuit 2:  Circuit: 'sky130_fd_io__gpiov2_octl_mux'
Circuit sky130_fd_io__gpiov2_octl_mux contains 4 device instances.
  Class: sky130_fd_pr__nfet_g5v0d10v5 instances:   2
  Class: sky130_fd_pr__pfet_g5v0d10v5 instances:   2
Circuit contains 7 nets.

Circuit 1 contains 4 devices, Circuit 2 contains 4 devices.
Circuit 1 contains 7 nets,    Circuit 2 contains 7 nets.

Circuits match with 4 symmetries.
Resolving automorphisms by property value.
Resolving automorphisms by pin name.
Netlists match uniquely.
Circuits match correctly.
Contents of circuit 1:  Circuit: 'sky130_fd_io__hvsbt_nand2'
```
After:
```
Contents of circuit 1:  Circuit: 'sky130_fd_io__gpiov2_octl_mux'
Circuit sky130_fd_io__gpiov2_octl_mux contains 4 device instances.
  Class: sky130_fd_pr__nfet_g5v0d10v5 instances:   2
  Class: sky130_fd_pr__pfet_g5v0d10v5 instances:   2
Circuit contains 7 nets.
Contents of circuit 2:  Circuit: 'sky130_fd_io__gpiov2_octl_mux'
Circuit sky130_fd_io__gpiov2_octl_mux contains 4 device instances.
  Class: sky130_fd_pr__nfet_g5v0d10v5 instances:   2
  Class: sky130_fd_pr__pfet_g5v0d10v5 instances:   2
Circuit contains 7 nets.

Circuit 1 contains 4 devices, Circuit 2 contains 4 devices.
Circuit 1 contains 7 nets,    Circuit 2 contains 7 nets.

Circuits match with 4 symmetries.
Resolving automorphisms by property value.
Resolving automorphisms by pin name. 
Netlists match uniquely.
Circuits match correctly.

Contents of circuit 1:  Circuit: 'sky130_fd_io__hvsbt_nand2'
```
3. Separate `Flattening instances` message from next subcircuit.
Before:
```
Circuit 1 contains 4 devices, Circuit 2 contains 4 devices.
Circuit 1 contains 8 nets,    Circuit 2 contains 6 nets. *** MISMATCH ***

  Flattening non-matched subcircuits sky130_fd_io__hvsbt_nand2 sky130_fd_io__hvsbt_nand2

Flattening instances of sky130_fd_io__hvsbt_nand2 in file /home/kanobailey/mpw-2/caravel-lvs/openlane/chip_io/runs/cvc/results/magic/chip_io.gds.spice
Flattening instances of sky130_fd_io__hvsbt_nand2 in file /home/kanobailey/mpw-2/caravel-lvs/verilog/gl/chip_io.v
Contents of circuit 1:  Circuit: 'sky130_fd_io__gpiov2_pdpredrvr_strong_nr2'
Circuit sky130_fd_io__gpiov2_pdpredrvr_strong_nr2 contains 24 device instances.
```
After:
```
Circuit 1 contains 4 devices, Circuit 2 contains 4 devices.
Circuit 1 contains 8 nets,    Circuit 2 contains 6 nets. *** MISMATCH ***

  Flattening non-matched subcircuits sky130_fd_io__hvsbt_nand2 sky130_fd_io__hvsbt_nand2
  
Flattening instances of sky130_fd_io__hvsbt_nand2 in file /home/kanobailey/mpw-2/caravel-lvs/openlane/chip_io/runs/cvc/results/magic/chip_io.gds.spice
Flattening instances of sky130_fd_io__hvsbt_nand2 in file /home/kanobailey/mpw-2/caravel-lvs/verilog/gl/chip_io.v

Contents of circuit 1:  Circuit: 'sky130_fd_io__gpiov2_pdpredrvr_strong_nr2'
Circuit sky130_fd_io__gpiov2_pdpredrvr_strong_nr2 contains 24 device instances.
```
4. Separate `property errors` from next subcircuit.
Before:
```
Combined 2 parallel devices.
Netlists match uniquely.
There were property errors.   
sky130_fd_io__hvsbt_nor_0/sky130_fd_pr__pfet_g5v0d10v51 vs. sky130_fd_io__hvsbt_norI488/sky130_fd_pr__pfet_g5v0d10v5I3:
 w circuit1: 2   circuit2: 1   (delta=66.7%, cutoff=1%)
Combined 2 parallel devices.
sky130_fd_io__hvsbt_nor_0/sky130_fd_pr__pfet_g5v0d10v50 vs. sky130_fd_io__hvsbt_norI488/sky130_fd_pr__pfet_g5v0d10v5I12:
 w circuit1: 2   circuit2: 1   (delta=66.7%, cutoff=1%)
Contents of circuit 1:  Circuit: 'sky130_fd_io__gpiov2_ipath_lvls'
Circuit sky130_fd_io__gpiov2_ipath_lvls contains 31 device instances.
```
After:
```
Combined 2 parallel devices.
Netlists match uniquely.
There were property errors.   
sky130_fd_io__hvsbt_nor_0/sky130_fd_pr__pfet_g5v0d10v51 vs. sky130_fd_io__hvsbt_norI488/sky130_fd_pr__pfet_g5v0d10v5I3:
 w circuit1: 2   circuit2: 1   (delta=66.7%, cutoff=1%)
Combined 2 parallel devices.
sky130_fd_io__hvsbt_nor_0/sky130_fd_pr__pfet_g5v0d10v50 vs. sky130_fd_io__hvsbt_norI488/sky130_fd_pr__pfet_g5v0d10v5I12:
 w circuit1: 2   circuit2: 1   (delta=66.7%, cutoff=1%)

Contents of circuit 1:  Circuit: 'sky130_fd_io__gpiov2_ipath_lvls'
Circuit sky130_fd_io__gpiov2_ipath_lvls contains 31 device instances.
```
5. Split error subcircuit list.
Before:
```
The following cells had property errors: sky130_fd_io__gpiov2_in_buf sky130_fd_io__signal_5_sym_hv_local_5term sky130_fd_io__gpiov2_ictl_logic sky130_fd_io__top_power_hvc_wpadv2 sky130_fd_io__top_ground_hvc_wpad
```
After:
```
The following cells had property errors:
 sky130_fd_io__gpiov2_in_buf
 sky130_fd_io__signal_5_sym_hv_local_5term
 sky130_fd_io__gpiov2_ictl_logic 
 sky130_fd_io__top_power_hvc_wpadv2
 sky130_fd_io__top_ground_hvc_wpad
```

Changes to the log file.
1. Separate `Equate pins` message from previous subcircuit.
Before:
```
Device classes sky130_fd_pr__nfet_g5v0d10v5 and sky130_fd_pr__nfet_g5v0d10v5 are equivalent.
Warning: Equate pins:  cell sky130_fd_pr__pfet_g5v0d10v5 has no definition, treated as a black box.
Warning: Equate pins:  cell sky130_fd_pr__pfet_g5v0d10v5 has no definition, treated as a black box.

Subcircuit pins:
Circuit 1: sky130_fd_pr__pfet_g5v0d10v5    |Circuit 2: sky130_fd_pr__pfet_g5v0d10v5
```
After:
```
Device classes sky130_fd_pr__nfet_g5v0d10v5 and sky130_fd_pr__nfet_g5v0d10v5 are equivalent.

Warning: Equate pins:  cell sky130_fd_pr__pfet_g5v0d10v5 has no definition, treated as a black box.
Warning: Equate pins:  cell sky130_fd_pr__pfet_g5v0d10v5 has no definition, treated as a black box.

Subcircuit pins:
Circuit 1: sky130_fd_pr__pfet_g5v0d10v5    |Circuit 2: sky130_fd_pr__pfet_g5v0d10v5
```
2. Separate `Merged` messages from previous subcircuit. Add file number to message. Add series merged counts. Differentiate between parallel and series.
Before:
```
Device classes sky130_fd_io__gpiov2_pdpredrvr_strong_nr3 and sky130_fd_io__gpiov2_pdpredrvr_strong_nr3 are equivalent.
Class sky130_fd_io__gpiov2_pupredrvr_strong_nd2:  Merged 2 devices.

Subcircuit summary:
Circuit 1: sky130_fd_io__gpiov2_pupredrvr_ |Circuit 2: sky130_fd_io__gpiov2_pupredrvr_
```
After:
```
Device classes sky130_fd_io__gpiov2_pdpredrvr_strong_nr3 and sky130_fd_io__gpiov2_pdpredrvr_strong_nr3 are equivalent.

Class sky130_fd_io__gpiov2_pupredrvr_strong_nd2(0):  Merged 2 parallel devices.
Class sky130_fd_io__gpiov2_pupredrvr_strong_nd2(0):  Merged 2 series devices.
Class sky130_fd_io__gpiov2_pupredrvr_strong_nd2(1):  Merged 2 series devices.
Subcircuit summary:
Circuit 1: sky130_fd_io__gpiov2_pupredrvr_ |Circuit 2: sky130_fd_io__gpiov2_pupredrvr_ 
```
3. Added file number to `disconnected net` message. Removed blank line before subcircuit.
Before:
```
Cell pin lists for sky130_fd_io__gpiov2_pupredrvr_strong_nd2 and sky130_fd_io__gpiov2_pupredrvr_strong_nd2 altered to match.

Cell sky130_fd_io__tk_tie_r_out_esd disconnected node: VSUBS 

Subcircuit summary:
Circuit 1: sky130_fd_io__tk_tie_r_out_esd  |Circuit 2: sky130_fd_io__tk_tie_r_out_esd
```
After:
```
Cell pin lists for sky130_fd_io__gpiov2_pupredrvr_strong_nd2 and sky130_fd_io__gpiov2_pupredrvr_strong_nd2 altered to match.

Cell sky130_fd_io__tk_tie_r_out_esd(0) disconnected node: VSUBS
Subcircuit summary:
Circuit 1: sky130_fd_io__tk_tie_r_out_esd  |Circuit 2: sky130_fd_io__tk_tie_r_out_esd
```
4. Removed spacing between `disconnected node` and `merged` messages for the same subcircuit.
Before:
```
Device classes sky130_fd_io__top_ground_hvc_wpad and sky130_fd_io__top_ground_hvc_wpad are equivalent.

Cell sky130_fd_io__xres4v2_in_buf disconnected node: m2_288_2593#
Cell sky130_fd_io__xres4v2_in_buf disconnected node: w_n32378_n9661#
Class sky130_fd_io__xres4v2_in_buf:  Merged 11 devices.

Cell sky130_fd_io__xres4v2_in_buf disconnected node: m2_288_2593#
Cell sky130_fd_io__xres4v2_in_buf disconnected node: w_n32378_n9661#

Subcircuit summary:
Circuit 1: sky130_fd_io__xres4v2_in_buf    |Circuit 2: sky130_fd_io__xres4v2_in_buf    
```
After:
```
Device classes sky130_fd_io__top_ground_hvc_wpad and sky130_fd_io__top_ground_hvc_wpad are equivalent.

Cell sky130_fd_io__xres4v2_in_buf(0) disconnected node: m2_288_2593#
Cell sky130_fd_io__xres4v2_in_buf(0) disconnected node: w_n32378_n9661#
Class sky130_fd_io__xres4v2_in_buf(0):  Merged 11 parallel devices.
Cell sky130_fd_io__xres4v2_in_buf(0) disconnected node: m2_288_2593#
Cell sky130_fd_io__xres4v2_in_buf(0) disconnected node: w_n32378_n9661#
Subcircuit summary:
Circuit 1: sky130_fd_io__xres4v2_in_buf    |Circuit 2: sky130_fd_io__xres4v2_in_buf
```
5. Split error subcircuit list.
Before:
```
The following cells had property errors: sky130_fd_io__gpiov2_in_buf sky130_fd_io__signal_5_sym_hv_local_5term sky130_fd_io__gpiov2_ictl_logic sky130_fd_io__top_power_hvc_wpadv2 sky130_fd_io__top_ground_hvc_wpad       
```
After:
```
The following cells had property errors:   
 sky130_fd_io__gpiov2_in_buf 
 sky130_fd_io__signal_5_sym_hv_local_5term 
 sky130_fd_io__gpiov2_ictl_logic           
 sky130_fd_io__top_power_hvc_wpadv2        
 sky130_fd_io__top_ground_hvc_wpad
```
