### PR TITLE
Add warning in installation docs regarding misleading apt-get

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ of CVS check-in notes on http://opencircuitdesign.com/netgen/.
 
 BUILDING NETGEN:
 ----------------
+
+> **NOTE**: In Ubuntu, **do not** install using `apt-get netgen`, as it installs a different (unknown) package.
+
 NETGEN version 1.5 uses the same "make" procedure as Magic version 8.1
 and IRSIM version 9.7:
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ of CVS check-in notes on http://opencircuitdesign.com/netgen/.
 BUILDING NETGEN:
 ----------------
 
-> **NOTE**: In Ubuntu, **do not** install using `apt-get netgen`, as it installs a different (unknown) package.
+> **NOTE**: In Ubuntu, **do not** install using `apt-get install netgen`, as it installs a different (unknown) package.
 
 NETGEN version 1.5 uses the same "make" procedure as Magic version 8.1
 and IRSIM version 9.7:


### PR DESCRIPTION
Inexperienced users of Ubuntu will probably try installing NETGEN with `sudo apt-get install netgen` (works with magic). This command works, but installs a different application called netgen, apparently a finite elements mesh generator... 

The pull request is just a suggestion to warn that, since netgen is sometimes part of a larger list of dependencies from other applications.