### PR TITLE
Add warning in installation docs regarding misleading apt-get

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ and IRSIM version 9.7:
 
 Note: For FreeBSD, use 'gmake' instead.
 
+Note: On Ubuntu, **do not** install using `apt-get install netgen`, since it installs a different (unknown) package.
+
 Note: On MacOS (Big Sur) follow the following procedure. If you have installed `xschem` and `magic` already on MacOS then steps (1) and (2) can likely be skipped.
 
 **1) Build Tcl for X11**


### PR DESCRIPTION
Inexperienced users of Ubuntu will probably try installing NETGEN with `sudo apt-get install netgen` (works with `magic`). This command works, but installs a different application called netgen, apparently a finite elements mesh generator...

The pull request is just a suggestion to warn that, since NETGEN is sometimes part of a larger list of dependencies from other applications.
