### PR TITLE
C99/Clang Patches

### DIFF
--- a/base/inetcomp.c
+++ b/base/inetcomp.c
@@ -17,6 +17,7 @@ along with this program; see the file copying.  If not, write to
 the Free Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA. */
 
 /* inetcomp.c -- a simple wrapper to the NETCOMP() function */
+#include "config.h"
 
 #include <stdio.h>
 #include "netgen.h"

--- a/base/netcmp.c
+++ b/base/netcmp.c
@@ -17,6 +17,7 @@ along with this program; see the file copying.  If not, write to
 the Free Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA. */
 
 /* netcmp.c  -- graph isomorphism testing */
+#include "config.h"
 
 #include "config.h"
 

--- a/base/test.c
+++ b/base/test.c
@@ -34,6 +34,8 @@ the Free Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA. */
 #include "print.h"
 #endif
 
+extern void Finsert(FILE *f);
+
 void test_entry(void) 
 { 
 

--- a/base/verilog.c
+++ b/base/verilog.c
@@ -1588,13 +1588,13 @@ skip_endmodule:
 			/* until bits in signal are exhausted or LHS is full.	    */
 
 			if (i != -1)
-			    sprintf(nodename, "%s[%d]", noderoot, i);
+			    snprintf(nodename, MAX_STR_LEN, "%s[%d]", noderoot, i);
 			else
-			    sprintf(nodename, lhs->name);
+			    strncpy(nodename, MAX_STR_LEN, lhs->name);
 			if (j != -1)
-			    sprintf(assignname, "%s[%d]", assignroot, j);
+			    snprintf(assignname, MAX_STR_LEN, "%s[%d]", assignroot, j);
 			else
-			    sprintf(assignname, rhs->name);
+			    strncpy(assignname, MAX_STR_LEN, rhs->name);
 
 			join(nodename, assignname);
 

--- a/netgen/inetcomp.c
+++ b/netgen/inetcomp.c
@@ -17,6 +17,7 @@ along with this program; see the file copying.  If not, write to
 the Free Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA. */
 
 /* inetcomp.c -- a simple wrapper to the NETCOMP() function */
+#include "config.h"
 
 #include <stdio.h>
 #include "netgen.h"

--- a/netgen/netcomp.c
+++ b/netgen/netcomp.c
@@ -17,6 +17,7 @@ along with this program; see the file copying.  If not, write to
 the Free Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA. */
 
 /* netcomp.c -- a simple wrapper to provide netlist comparison functionality */
+#include "config.h"
 
 #include <stdio.h>
 #include "netgen.h"

--- a/netgen/netgen_main.c
+++ b/netgen/netgen_main.c
@@ -23,6 +23,7 @@ the Free Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA. */
 #include <stdlib.h>  /* for getenv */
 #endif
 #include "netgen.h"
+#include "print.h"
 
 int main(int argc, char **argv)
 {

--- a/netgen/ntk2xnf.c
+++ b/netgen/ntk2xnf.c
@@ -20,9 +20,11 @@ along with this program; see the file copying.  If not, write to
 the Free Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA. */
 
 /* ntk2xnf.c  -- a simple wrapper to translate .ntk to Xilinx XNF format */
+#include "config.h"
 
 #include <stdio.h>
 #include "netgen.h"
+#include "xilinx.h"
 
 #ifdef HAVE_X11
 /* the following two X procedures are to permit linking


### PR DESCRIPTION
These are a couple of changes that improve C99 and Clang compat:

* Add `#include`s where appropriate.
* Replace `sprintf`, marked unsafe, with safer alternatives.