### PR TITLE
Fix tclnetgen.so build on GCC 14+: signal handler type

### DIFF
--- a/base/netcmp.c
+++ b/base/netcmp.c
@@ -52,7 +52,7 @@ the Free Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA. */
 
 #ifdef TCL_NETGEN
 int InterruptPending = 0;
-void (*oldinthandler)() = SIG_DFL;
+void (*oldinthandler)(int) = SIG_DFL;
 extern Tcl_Interp *netgeninterp;
 extern int check_interrupt();
 #endif


### PR DESCRIPTION
On GCC 14+ (Fedora 41+, Debian 13+, Ubuntu 24.04+), tclnetgen.so fails to build because of a K&R-style empty parameter list at base/netcmp.c:55:

```c
void (*oldinthandler)() = SIG_DFL;
```

GCC 14+ infers this as void(*)(void) and rejects the assignment from signal(SIGINT, handler), which returns void(*)(int):

```
netcmp.c:8784:19: error: incompatible-pointer-types
 signal(SIGINT, oldinthandler);
```

-Wincompatible-pointer-types is now a default error in GCC 14+, so the build stops there.

The fix changes the declaration to match the actual usage as a SIGINT handler:

```c
void (*oldinthandler)(int) = SIG_DFL;
```

Tested on Fedora 43 (GCC 15.2) inside a containerized build of netgen 1.5.318. Restores tclnetgen.so build, so netgen -batch lvs mode works again. No behavior change.

Possibly related to #85 (make install fails [tclnetgen.dylib]), same build path of the Tcl extension.